### PR TITLE
oci_rules containers sysimage base image helpers

### DIFF
--- a/oak_containers_system_image/README.md
+++ b/oak_containers_system_image/README.md
@@ -6,5 +6,22 @@
 
 # System Image Build Tools
 
+## Full System Image Tools
+
+`build.sh` and `Dockerfile`
+
 Tools for building the Oak Containers system image. The system image contains
 the guest Linux distribution and the Orchestrator.
+
+## Base System Image Tools
+
+`build-base.sh` and `base_iamge.Dockerfile`
+
+This directory contains files needed to rebuild the base image used by the
+system container.
+
+The base image contains things that rarely change for the image: the base
+operating system, network configuration, and service enablements.
+
+This image is used to build the system container image with `oci_rules`,
+avoiding the need for Docker when rebuilding a system image container.

--- a/oak_containers_system_image/base_image.Dockerfile
+++ b/oak_containers_system_image/base_image.Dockerfile
@@ -1,0 +1,32 @@
+ARG debian_snapshot=sha256:f0b8edb2e4436c556493dce86b941231eead97baebb484d0d5f6ecfe4f7ed193
+FROM debian@${debian_snapshot}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get --yes update \
+    && apt-get install --yes --no-install-recommends \
+    systemd systemd-sysv dbus udev runc \
+    # Cleanup
+    && apt-get clean \
+    && rm --recursive --force /var/lib/apt/lists/*
+
+# Clean up some stuff we don't need
+RUN rm -rf /usr/share/doc /usr/share/info /usr/share/man
+
+# Copy config files
+COPY files /
+
+# Prepare network
+RUN systemctl enable systemd-networkd
+
+# Enable the two Oak services
+# They don't exist yet in this image, but the symlinks will be properly created.
+RUN systemctl enable oak-orchestrator
+RUN systemctl enable oak-syslogd
+
+# Only enable interactive logins if the kernel was booted with "debug" flag.
+RUN systemctl disable getty@
+RUN systemctl enable root-passwd
+
+# Don't bother starting the graphical interface, let's stick with the basic multi-user target.
+RUN systemctl set-default multi-user

--- a/oak_containers_system_image/build-base.sh
+++ b/oak_containers_system_image/build-base.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly SCRIPTS_DIR="$(dirname "$0")"
+
+cd "$SCRIPTS_DIR"
+
+# Fix the file permissions that will be loaded into the system image, as Git doesn't track them.
+# Unfortunately we can't do it in Dockerfile (with `COPY --chown`), as that requires BuildKit.
+chmod --recursive a+rX files/
+
+docker build . --tag=oak-containers-sysimage-base:latest --file base_image.Dockerfile
+
+readonly DOCKER_IMAGE_NAME='europe-west2-docker.pkg.dev/oak-ci/oak-containers-sysimage-base/oak-containers-sysimage-base:latest'
+docker tag oak-containers-sysimage-base:latest "${DOCKER_IMAGE_NAME}"
+docker push "${DOCKER_IMAGE_NAME}"


### PR DESCRIPTION
These tools allow us to push the base system image container (everything but our custom rust binaries) on-demand. It's not expected that this base will change frequently, so the on-demand approach to updates is sufficient for now.

b/326961309
b/311651716